### PR TITLE
chore: Add vscode config for Black Formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "black-formatter.args" : ["--config", "${workspaceFolder}/pyproject.toml"],
+    "black-formatter.path":[
+        "poetry","run","python", "-m", "black"
+    ]
+}


### PR DESCRIPTION
### Description
Add VS Code Config for using Black in virtual env. The default version of Black for the latest Black Formatter Extension cannot parse the code.

### Changes Made
n/a

### Related Issues
n/a

### Additional Notes
Before:
<img width="893" alt="image" src="https://github.com/user-attachments/assets/335008d5-ca81-4d09-ac01-f5ad616da4c4">
After:
<img width="834" alt="image" src="https://github.com/user-attachments/assets/f1c3f828-fbba-4c02-9ebc-cf0448a12a37">

