### PR TITLE
fix: Disable Swagger UI docs for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ poetry install
 Run the FastAPI server
 
 ```sh
-poetry run fastapi run src/server.py
+poetry run fastapi dev src/server.py
 ```
 
 ## Running the scraper

--- a/src/server.py
+++ b/src/server.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from datetime import datetime
 from typing import Union
 
@@ -9,7 +10,15 @@ from tinydb import Query, TinyDB
 
 from .schemas import CourseSchema
 
-app = FastAPI()
+# Check if the application is running in development mode
+is_dev_mode = "dev" in sys.argv
+
+# Configure FastAPI based on the mode
+app = FastAPI(
+    docs_url="/docs" if is_dev_mode else None,
+    redoc_url="/redoc" if is_dev_mode else None,
+)
+
 db = TinyDB("src/db.json")
 Course = Query()
 


### PR DESCRIPTION
### Description
Disable Swagger UI docs for production.

### Changes Made
Added a check to see whether fastapi was run in development or production mode and only enable Swagger UI docs for development mode.

### Related Issues
Fixes #33 

### Additional Notes
N/A
