### PR TITLE
fix: Add json-repair to handle invalid json resp

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -422,6 +422,17 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "json-repair"
+version = "0.30.0"
+description = "A package to repair broken json strings"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "json_repair-0.30.0-py3-none-any.whl", hash = "sha256:bda4a5552dc12085c6363ff5acfcdb0c9cafc629989a2112081b7e205828228d"},
+    {file = "json_repair-0.30.0.tar.gz", hash = "sha256:24f12087a0e385ed47207eab1fca12bffd473e48db5bb803793d6c4fd97377ce"},
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -1334,4 +1345,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "91169b8abde8d275a2e55b43d82a044c4b1fe7f4992329fe335147d85eabba52"
+content-hash = "b1fe2786161b29dc9638b3552fd264b548478ad51051c836fbd5b90fc7f71d77"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ nanoid = "^2.0.0"
 black = "^24.8.0"
 pydantic = "^2.9.2"
 rich = "^13.9.1"
+json-repair = "^0.30.0"
 
 [tool.poetry.scripts]
 scraper = "src.scraper:main"

--- a/src/data_fetcher.py
+++ b/src/data_fetcher.py
@@ -1,5 +1,7 @@
-import requests
 import time
+
+import requests
+import json_repair
 
 
 class DataFetcher:
@@ -36,7 +38,7 @@ class DataFetcher:
             print(f"Error: HTTP {response.status_code} - {response.text}")
             return {}
 
-        resp = response.json()
+        resp = json_repair.loads(response.text)
 
         if resp.get("status") != "success":
             print(f"API Error: {resp.get('error', 'Unknown error')}")

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -46,24 +46,24 @@ def main():
                     course_id, term, year, offer
                 )
 
-                subject = course_details[0]["SUBJECT"]
-                catalog_nbr = course_details[0]["CATALOG_NBR"]
-
-                # Course Custom ID
-                course_cid = get_short_hash(
-                    f"{subject}{catalog_nbr}{year}{term}{course_id}"
-                )
-                db.insert(
-                    {
-                        "id": course_cid,
-                        "course_id": course_id,
-                        "term": term,
-                        "year": year,
-                        "details": course_details,
-                    }
-                )
-
                 if isinstance(course_details, list) and len(course_details) > 0:
+                    subject = course_details[0]["SUBJECT"]
+                    catalog_nbr = course_details[0]["CATALOG_NBR"]
+
+                    # Course Custom ID
+                    course_cid = get_short_hash(
+                        f"{subject}{catalog_nbr}{year}{term}{course_id}"
+                    )
+                    db.insert(
+                        {
+                            "id": course_cid,
+                            "course_id": course_id,
+                            "term": term,
+                            "year": year,
+                            "details": course_details,
+                        }
+                    )
+
                     session = course_details[0].get("SESSION_CD", "N/A")
 
                     course_class_list = data_parser.get_course_class_list(


### PR DESCRIPTION
### Description
This issue is mainly caused by the invalid escape `\o` in the response JSON data. 
Test example: https://courseplanner.uni.adelaide.edu.au/course/1-2024-109708-4410

### Changes Made
- Add a json-repair package to repair the json data
- Check the course_details structure before processing courses to be more robust

### Related Issues
Fixes #38 

### Additional Notes
<img width="576" alt="image" src="https://github.com/user-attachments/assets/fb1fe7d1-3612-4ecf-a8bc-f86c349fc24c">