### PR TITLE
fix: Split meetings which have multiple days

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -368,23 +368,29 @@ def get_course(id: str):
                         "meetings": [],
                     }
                     for meeting in class_info.get("meetings", []):
-                        meeting_entry = {
-                            "day": meeting.get("days", ""),
-                            "location": meeting.get("location", ""),
-                            "date": meeting_date_convert(meeting.get("dates", "")),
-                            "time": {
-                                "start": meeting_time_convert(
-                                    meeting.get("start_time", "")
-                                ),
-                                "end": meeting_time_convert(
-                                    meeting.get("end_time", "")
-                                ),
-                            },
-                        }
-                        class_entry["meetings"].append(meeting_entry)
+                        days = [
+                            day.strip()
+                            for day in meeting.get("days", "").split(",")
+                            if day.strip()
+                        ]
 
-                    class_list_entry["classes"].append(class_entry)
+                        for day in days:
+                            meeting_entry = {
+                                "day": day,
+                                "location": meeting.get("location", ""),
+                                "date": meeting_date_convert(meeting.get("dates", "")),
+                                "time": {
+                                    "start": meeting_time_convert(
+                                        meeting.get("start_time", "")
+                                    ),
+                                    "end": meeting_time_convert(
+                                        meeting.get("end_time", "")
+                                    ),
+                                },
+                            }
+                            class_entry["meetings"].append(meeting_entry)
 
+                class_list_entry["classes"].append(class_entry)
                 response["class_list"].append(class_list_entry)
 
     try:


### PR DESCRIPTION
### Description
Split meetings which have multiple days in `day` field.

### Changes Made
Split meetings which have multiple days to several different meetings.

### Related Issues
Fixes #25, contributes to #41

### Additional Notes
N/A
