### PR TITLE
fix: Support class times that don't start on the hour

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -368,6 +368,12 @@ def get_course(id: str):
                         "meetings": [],
                     }
                     for meeting in class_info.get("meetings", []):
+                        # Skip weekend meetings
+                        if "Saturday" in meeting.get(
+                            "days", ""
+                        ) or "Sunday" in meeting.get("days", ""):
+                            continue
+
                         meeting_entry = {
                             "day": meeting.get("days", ""),
                             "location": meeting.get("location", ""),

--- a/src/server.py
+++ b/src/server.py
@@ -373,11 +373,6 @@ def get_course(id: str):
                         "meetings": [],
                     }
                     for meeting in class_info.get("meetings", []):
-                        # Skip weekend meetings
-                        if "Saturday" in meeting.get(
-                            "days", ""
-                        ) or "Sunday" in meeting.get("days", ""):
-                            continue
 
                         meeting_entry = {
                             "day": meeting.get("days", ""),

--- a/src/server.py
+++ b/src/server.py
@@ -113,15 +113,20 @@ def meeting_time_convert(raw_time: str) -> str:
     Returns:
         formatted_time (str): The formatted meeting time in the format of "HH:mm"
     """
-    period = raw_time[-2:]
-    hour = int(raw_time.replace(period, "").strip())
+    if ":" in raw_time:
+        time_part, period = raw_time[:-2], raw_time[-2:].lower()
+        hour, minute = map(int, time_part.split(":"))
+    else:
+        period = raw_time[-2:].lower()
+        hour = int(raw_time[:-2])
+        minute = 0
 
-    if period.lower() == "pm" and hour != 12:
+    if period == "pm" and hour != 12:
         hour += 12
-    elif period.lower() == "am" and hour == 12:
+    elif period == "am" and hour == 12:
         hour = 0
 
-    formatted_time = f"{str(hour).zfill(2)}:00"
+    formatted_time = f"{str(hour).zfill(2)}:{str(minute).zfill(2)}"
     return formatted_time
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -373,7 +373,6 @@ def get_course(id: str):
                         "meetings": [],
                     }
                     for meeting in class_info.get("meetings", []):
-
                         meeting_entry = {
                             "day": meeting.get("days", ""),
                             "location": meeting.get("location", ""),


### PR DESCRIPTION
### Description
Support class times that don't start on the hour, like 10:30am.

### Changes Made
Parse both the hour and minute components (if it exists) from the time element in the db.

### Related Issues
Fixes #32, and closes #41

### Additional Notes
N/A
