### PR TITLE
feat(ci): Use arm runner for production workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     environment: Production
     permissions:
       id-token: write
@@ -28,11 +28,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Set up QEMU for ARM64
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
 
       - name: Cache Docker layers
         uses: actions/cache@v4


### PR DESCRIPTION
### Description
Use arm runner for production workflow.

### Changes Made
Use `ubuntu-24.04-arm` runner and remove QEMU step for production workflow.

### Related Issues
N/A

### Additional Notes
N/A
