### PR TITLE
chore(server): Set and parse YEAR env var, default current_year, and return available_seats

### DIFF
--- a/src/schemas.py
+++ b/src/schemas.py
@@ -32,6 +32,7 @@ class MeetingSchema(BaseModel):
 
 class ClassSchema(BaseModel):
     number: str
+    available_seats: str
     meetings: List[MeetingSchema]
 
 

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -234,7 +234,10 @@ def main():
     Base.metadata.create_all(engine)
     Session.configure(bind=engine)
 
-    year = dotenv_values().get("YEAR")
+    year_str = dotenv_values().get("YEAR")
+    if year_str is None:
+        raise ValueError("YEAR environment variable is not set")
+    year = int(year_str)
 
     # Create lock for thread-safe operations
     lock = Lock()

--- a/src/server.py
+++ b/src/server.py
@@ -75,7 +75,10 @@ def get_db():
 
 def current_year() -> int:
     """Gets the current year."""
-    return dotenv_values().get("YEAR")
+    year_str = dotenv_values().get("YEAR")
+    if year_str is None:
+        return datetime.now().year
+    return int(year_str)
 
 
 def current_sem() -> str:
@@ -104,7 +107,7 @@ def get_term_number(db, year: int, term: str) -> int:
     )
 
 
-def meeting_date_convert(raw_date: str) -> dict[str]:
+def meeting_date_convert(raw_date: str) -> dict[str, str]:
     """Converts the date format given in the meetings to "MM-DD"
     Args:
         raw_date (str): The given meeting date in the format of "DD {3-char weekday}
@@ -400,6 +403,7 @@ def get_course(course_cid: str, db: Session = Depends(get_db)):
             class_list_entry = class_groups[class_type]
             class_entry = {
                 "number": str(class_group.class_nbr),
+                "available_seats": str(class_group.available),
                 "meetings": [],
             }
             for meeting in class_group.meetings:


### PR DESCRIPTION
### Description
Add meetings field to ClassSchema and available_seats attribute as requested in Issue #74

### Changes Made
fix(scraper): Ensure YEAR environment variable is set and convert to int
fix(server): Update current_year function to return current year if YEAR is not set
fix(server): Update get_course to include available_seats in response

### Related Issues
Fixes #74 

### Additional Notes
None
