### PR TITLE
fix: correct course unit scraping (wrong key, non-digit values)

### DIFF
--- a/src/scraper.py
+++ b/src/scraper.py
@@ -63,6 +63,21 @@ def join_str_if_iterable(value):
     return str(value)
 
 
+def parse_units(value, default: int = 6) -> int:
+    """Parse a scraped unit value into an int.
+
+    The scraped text can contain non-digit characters (e.g. "3 units"
+    instead of a bare "3"), so only the leading run of digits is used.
+    Falls back to `default` if `value` is missing or contains no digits.
+    """
+    if value is None:
+        return default
+    match = re.search(r"\d+", str(value))
+    if not match:
+        return default
+    return int(match.group())
+
+
 def process_course(course, year, subject, engine, progress, subject_task, lock):
     """Process a single course and insert data into the database."""
     try:
@@ -109,7 +124,7 @@ def process_course(course, year, subject, engine, progress, subject_task, lock):
                 title=title,
                 campus=join_str_if_iterable(campus),
                 level_of_study=course_details.get("level_of_study", "N/A"),
-                units=int(course_details.get("unit_value", "6")),
+                units=parse_units(course_details.get("units")),
                 course_coordinator=course_details.get("course_coordinator", "N/A"),
                 course_level=course_details.get("course_level", "N/A"),
                 course_overview=course_details.get("course_overview", "N/A"),

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,37 @@
+"""Tests for scraper.py's unit-value parsing.
+
+Regression test for the "units" scraping bug: `process_course` looked
+up `course_details["unit_value"]`, but `data_parser.get_course_details`
+returns the field under the key "units", so the lookup always fell
+back to the default of 6. Additionally, the raw scraped value could
+contain non-digit text (e.g. "3 units"), which crashed a bare
+`int(...)` conversion.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from scraper import parse_units  # noqa: E402
+
+
+def test_parse_units_plain_digits():
+    assert parse_units("12") == 12
+
+
+def test_parse_units_with_trailing_text():
+    """Scraped text like "3 units" should still parse to 3, not crash."""
+    assert parse_units("3 units") == 3
+
+
+def test_parse_units_missing_falls_back_to_default():
+    assert parse_units(None) == 6
+
+
+def test_parse_units_unparseable_falls_back_to_default():
+    assert parse_units("N/A") == 6
+
+
+def test_parse_units_custom_default():
+    assert parse_units(None, default=0) == 0


### PR DESCRIPTION
### Summary

Fixes #114.

`process_course` in `src/scraper.py` looked up
`course_details.get("unit_value", "6")`, but
`data_parser.get_course_details()` returns the parsed field under the
key `"units"` (see `data_parser.py`'s `course_details` dict and the
`"unit value": "units"` label mapping in `parse_course_text`). Because
of the key mismatch, the lookup always missed and fell through to the
`"6"` default -- every scraped course was stored with 6 units
regardless of its actual value (e.g. Industry Project in Project
Management, BUSI6040, which is actually worth 12 units).

Separately, the raw scraped text for this field isn't guaranteed to
be a bare integer (e.g. `"3 units"`), so the previous bare
`int(course_details.get(...))` call could also raise a `ValueError`
outright.

### Fix

- Look up the correct key, `"units"`.
- Add a small `parse_units()` helper that extracts the leading run of
  digits from the scraped value via regex, falling back to the
  default (6) if the value is missing or has no digits at all --
  fixing both the key mismatch and the potential crash on non-digit
  text in one place.

### Testing

This repo doesn't currently have a test suite, so I added
`tests/test_scraper.py` with unit tests for `parse_units()` covering:
plain digit strings, digit strings with trailing text (the
`"3 units"` case), a missing value, an unparseable value, and a
custom default. All 5 pass. Reverting just the `scraper.py` change
(keeping the test) makes the import fail with
`ImportError: cannot import name 'parse_units' from 'scraper'`,
confirming the test actually exercises the fix.

`ruff check` is clean on both changed files.
