### PR TITLE
feat: Add course level to API responses

### DIFF
--- a/src/schemas.py
+++ b/src/schemas.py
@@ -82,6 +82,7 @@ class CourseSchema(BaseModel):
     course_coordinator: Optional[str] = None
     course_overview: str
     level_of_study: str
+    course_level: str
     course_outline_url: Optional[str] = None
     learning_outcomes: Optional[List[LearningOutcomeSchema]] = None
     textbooks: Optional[str] = None

--- a/src/server.py
+++ b/src/server.py
@@ -328,6 +328,7 @@ def get_subject_courses(
                 },
                 "university_wide_elective": entry.university_wide_elective,
                 "level_of_study": entry.level_of_study,
+                "course_level": entry.course_level,
                 "campus": entry.campus,
             }
         )
@@ -413,6 +414,7 @@ def get_course(course_cid: str, db: Session = Depends(get_db)):
         "course_coordinator": course.course_coordinator,
         "course_overview": course.course_overview,
         "level_of_study": course.level_of_study,
+        "course_level": course.course_level,
         "course_url": course.url,
         "course_outline_url": course.course_outline_url,
         "learning_outcomes": learning_outcomes,


### PR DESCRIPTION
### Description

Return course_level in API responses 

### Changes Made

- Updated server.py to return course_level
- Updated schemas.py to include course_level in CourseSchema

### Related Issues

Closes #115

### Additional Notes
N/A
